### PR TITLE
exp: WASI support through TinyGo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ build-wasm:
 build-wasm-tinygo:
 	tinygo build -o app/wasm/main-tinygo.wasm -target wasm -no-debug -gc leaking ./cmd/wasm
 
+build-wasi-tinygo:
+	tinygo build -o app/wasm/main-tinygo.wasm -target wasi -no-debug -gc leaking ./cmd/wasi
+
 watch-wasm:
 	go run github.com/cosmtrek/air@latest
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build-wasm-tinygo:
 	tinygo build -o app/wasm/main-tinygo.wasm -target wasm -no-debug -gc leaking ./cmd/wasm
 
 build-wasi-tinygo:
-	tinygo build -o app/wasm/main-tinygo.wasm -target wasi -no-debug -gc leaking ./cmd/wasi
+	tinygo build -o app/wasm/main-wasi.wasm -target wasm ./cmd/wasi
 
 watch-wasm:
 	go run github.com/cosmtrek/air@latest

--- a/app/js/imagewand.js
+++ b/app/js/imagewand.js
@@ -4,6 +4,7 @@ const InstanceType = {
   STANDARD: "STANDARD",
   WORKER: "WORKER",
   TINYGO: "TINYGO",
+  WASI: "WASI",
 };
 
 export const formatGoNumber = {
@@ -46,6 +47,22 @@ export const ImageWand = async (t) => {
 
       // uses the WASM binary exported functions
       return Promise.resolve(wand);
+    }
+
+    case InstanceType.WASI: {
+      console.log('Starting as "wasi"');
+      await import("./wasm-tinygo-exec.js");
+      const go = new window.Go();
+
+      const obj = await WebAssembly.instantiateStreaming(
+        fetch("/wasm/main-wasi.wasm"),
+        go.importObject
+      );
+      const wasm = obj.instance;
+      go.run(wasm);
+
+      // uses the WASM binary exported functions
+      return Promise.resolve(wasm.exports);
     }
 
     default:

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -15,10 +15,16 @@ import { fromURL, formatToNumber } from "./imagewand.js";
     setTimeout(async () => {
       // Calls Golang WASM runtime and receive HTTP response
       const format = controller.getFormat();
-      const arrayBuffer = await imagewand.convertFromBlob(
-        formatToNumber(format),
-        new Uint8Array(buf)
-      );
+
+      imagewand.reset();
+      new Uint8Array(buf).forEach((b) => imagewand.appendToBuffer(b));
+      await imagewand.convertFromBlob(formatToNumber(format));
+      const outputSize = imagewand.getOutputSize();
+      const arrayBuffer = new Uint8Array(outputSize);
+      for (let i = 0; i < outputSize; i++) {
+        arrayBuffer[i] = imagewand.getOutputAtPos(i);
+      }
+
       const blob = new Blob([arrayBuffer]);
 
       // Creates local ObjectURL, used for download and display

--- a/cmd/wasi/main.go
+++ b/cmd/wasi/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+
+	"github.com/brunoluiz/imagewand"
+)
+
+type image []byte
+
+var input image;
+var output image;
+
+//export reset
+func reset() {
+	input = []byte{}
+	output = []byte{}
+}
+
+//export appendToBuffer
+func appendToBuffer(i byte) {
+	input = append(input, i)
+}
+
+//export getOutputSize
+func getOutputSize() int {
+	return len(output)
+}
+
+//export getOutputAtPos
+func getOutputAtPos(i int) byte {
+	return output[i]
+}
+
+var fileFormatFromInt = map[int]imagewand.FileFormat{
+	1: imagewand.FileFormatJPG,
+	2: imagewand.FileFormatPNG,
+	3: imagewand.FileFormatGIF,
+	4: imagewand.FileFormatTIFF,
+	5: imagewand.FileFormatBMP,
+}
+
+//export convertFromBlob
+func convertFromBlob(format int) {
+	img, err := imagewand.New(bytes.NewBuffer(input))
+	if err != nil {
+		panic(err)
+	}
+
+	f, ok := fileFormatFromInt[format]
+	if !ok {
+		panic("format not supported")
+	}
+
+	b := bytes.NewBuffer([]byte{})
+	if err := img.Convert(b, f); err != nil {
+		panic(err)
+	}
+
+	output = b.Bytes()
+	input = []byte{}
+}
+
+func main() {
+}


### PR DESCRIPTION
This is just an experiment to see if I could add WASI support with
TinyGo compiler. It is doable, but accessing the shared memory proved
quite a pain.

- Reserving buffer space in memory doesn't work, as this is the seemly
  most recommended way if you want to use `wasm.exports.memory.buffer`
- Calling append/total methods seems quite counter productive
- Really, the code seems quite ugly... there must be a btter way of
  doing this